### PR TITLE
Ignore the bosch_locator_bridge_utils package on Rolling.

### DIFF
--- a/rolling.ignored
+++ b/rolling.ignored
@@ -1,0 +1,1 @@
+bosch_locator_bridge_utils


### PR DESCRIPTION
This package has a dependency (`nav2_util`) which is currently unavailable in Rolling.

When this dependency is detected as missing it causes bloom to abort generating artifacts for the entire repository.